### PR TITLE
PMT #113485 Add back links to lab activities

### DIFF
--- a/themes/ctl-histologylab/layouts/lab_activities/single.html
+++ b/themes/ctl-histologylab/layouts/lab_activities/single.html
@@ -1,5 +1,0 @@
-{{ partial "header.html" . }}
-
-{{ partial "cover.html" . }}
-
-{{ partial "footer.html" . }}

--- a/themes/ctl-histologylab/layouts/lab_activity/single.html
+++ b/themes/ctl-histologylab/layouts/lab_activity/single.html
@@ -1,0 +1,7 @@
+{{ partial "header.html" . }}
+
+{{ partial "cover.html" . }}
+<div>
+    <a href="/{{ .Params.lab_topic_name }}/">Back to Lab {{ .Params.lab_topic_number }}</a>
+</div>
+{{ partial "footer.html" . }}


### PR DESCRIPTION
This commit also moves the templates for lab_activities to a correctly
named directory.