### PR TITLE
PMT #114945: Add leading and trailing wildcards to search

### DIFF
--- a/themes/ctl-histologylab/static/js/src/search.js
+++ b/themes/ctl-histologylab/static/js/src/search.js
@@ -49,7 +49,9 @@ if (typeof require === 'function') {
         this.results = this.index.query(function(q) {
             mainTerm.forEach(function(param) {
                 if (param) {
-                    q.term(param.toLowerCase());
+                    q.term(param.toLowerCase(), {
+                        wildcard: lunr.Query.wildcard.TRAILING |
+                        lunr.Query.wildcard.TRAILING });
                 }
             });
         });

--- a/themes/ctl-histologylab/static/js/tests/test-search.js
+++ b/themes/ctl-histologylab/static/js/tests/test-search.js
@@ -38,10 +38,10 @@ describe('Search.doSearch()', function() {
         s.doSearch('abc');
         assert.strictEqual(s.results.length, 0);
 
-        s.doSearch('hematopoiesis');
+        s.doSearch('hematopoiesi');
         assert.strictEqual(s.results.length, 2);
 
-        s.doSearch('the liver is the largest gland in the body');
+        s.doSearch('the liver is the largest gland');
         assert.strictEqual(s.results[0].ref, '913bf017ba988f08bdbdd026ba7b261b');
     });
 


### PR DESCRIPTION
This commit adds wildcards to provide what I think is a better user
experience. Here's what I mean: without wildcards Lunr has trouble
finding partial word matches, but it does really well with matching
strings. For example, w/o wildcards, when searching "the liver is the
largest gland in the body" the top result will be the page that starts
with that sentence.

Great, except say that your next search is for
"Hematopoiesis" but your not sure of the exact spelling. Not including
wildcards means that Lunr won't match until you get the exact word to
match. That seems like a crumby experience - most users, I presume, are
going to be searching for one or two terms at a time, not the exact
strings from pages that they remember verbatim. Hence, adding wildcards.

This commit also tweaks some tests to match on a partial word, and
reduced the length of a long string match to match to the correct page.