### PR TITLE
PMT #116112: Broken image links bug

### DIFF
--- a/content/assets_c/2009/07/01-1168.md
+++ b/content/assets_c/2009/07/01-1168.md
@@ -3,4 +3,4 @@ title: 01-1168
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/01.jpg" height="750" alt="01.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/01.jpg" height="750" alt="01.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/05-1180.md
+++ b/content/assets_c/2009/07/05-1180.md
@@ -3,4 +3,4 @@ title: 05-1180
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/05.jpg" width="800" alt="05.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/05.jpg" width="800" alt="05.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/07-1186.md
+++ b/content/assets_c/2009/07/07-1186.md
@@ -3,4 +3,4 @@ title: 07-1186
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/07.jpg" height="750" alt="07.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/07.jpg" height="750" alt="07.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/08-1189.md
+++ b/content/assets_c/2009/07/08-1189.md
@@ -3,4 +3,4 @@ title: 08-1189
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/08.jpg" width="800" alt="08.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/08.jpg" width="800" alt="08.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/11-1198.md
+++ b/content/assets_c/2009/07/11-1198.md
@@ -3,4 +3,4 @@ title: 11-1198
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/11.jpg" width="800" alt="11.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/11.jpg" width="800" alt="11.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/12-1201.md
+++ b/content/assets_c/2009/07/12-1201.md
@@ -3,4 +3,4 @@ title: 12-1201
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/12.jpg" height="750" alt="12.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/12.jpg" height="750" alt="12.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/13-1204.md
+++ b/content/assets_c/2009/07/13-1204.md
@@ -3,4 +3,4 @@ title: 13-1204
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/13.jpg" height="750" alt="13.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/13.jpg" height="750" alt="13.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/14-1207.md
+++ b/content/assets_c/2009/07/14-1207.md
@@ -3,4 +3,4 @@ title: 14-1207
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/14.jpg" width="800" alt="14.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/14.jpg" width="800" alt="14.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/20-1225.md
+++ b/content/assets_c/2009/07/20-1225.md
@@ -3,4 +3,4 @@ title: 20-1225
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/20.jpg" width="800" alt="20.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/20.jpg" width="800" alt="20.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/21-1234.md
+++ b/content/assets_c/2009/07/21-1234.md
@@ -3,4 +3,4 @@ title: 21-1234
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/21.jpg" width="800" alt="21.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/21.jpg" width="800" alt="21.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/22-1237.md
+++ b/content/assets_c/2009/07/22-1237.md
@@ -3,4 +3,4 @@ title: 22-1237
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/22.jpg" height="750" alt="22.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/22.jpg" height="750" alt="22.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/23-1240.md
+++ b/content/assets_c/2009/07/23-1240.md
@@ -3,4 +3,4 @@ title: 23-1240
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/23.jpg" width="800" alt="23.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/23.jpg" width="800" alt="23.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/24-1243.md
+++ b/content/assets_c/2009/07/24-1243.md
@@ -3,4 +3,4 @@ title: 24-1243
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/24.jpg" width="800" alt="24.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/24.jpg" width="800" alt="24.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/25-1246.md
+++ b/content/assets_c/2009/07/25-1246.md
@@ -3,4 +3,4 @@ title: 25-1246
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/25.jpg" width="800" alt="25.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/25.jpg" width="800" alt="25.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/26-1249.md
+++ b/content/assets_c/2009/07/26-1249.md
@@ -3,4 +3,4 @@ title: 26-1249
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/26.jpg" height="750" alt="26.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/26.jpg" height="750" alt="26.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/27-1252.md
+++ b/content/assets_c/2009/07/27-1252.md
@@ -3,4 +3,4 @@ title: 27-1252
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/27.jpg" height="750" alt="27.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/27.jpg" height="750" alt="27.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/28-1255.md
+++ b/content/assets_c/2009/07/28-1255.md
@@ -3,4 +3,4 @@ title: 28-1255
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/28.jpg" width="800" alt="28.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/28.jpg" width="800" alt="28.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/29-1258.md
+++ b/content/assets_c/2009/07/29-1258.md
@@ -3,4 +3,4 @@ title: 29-1258
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/29.jpg" height="750" alt="29.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/29.jpg" height="750" alt="29.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/30-1261.md
+++ b/content/assets_c/2009/07/30-1261.md
@@ -3,4 +3,4 @@ title: 30-1261
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/30.jpg" height="750" alt="30.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/30.jpg" height="750" alt="30.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/31-1264.md
+++ b/content/assets_c/2009/07/31-1264.md
@@ -3,4 +3,4 @@ title: 31-1264
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/31.jpg" width="800" alt="31.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/31.jpg" width="800" alt="31.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/32-1267.md
+++ b/content/assets_c/2009/07/32-1267.md
@@ -3,4 +3,4 @@ title: 32-1267
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/32.jpg" width="800" alt="32.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/32.jpg" width="800" alt="32.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/33-1270.md
+++ b/content/assets_c/2009/07/33-1270.md
@@ -3,4 +3,4 @@ title: 33-1270
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/33.jpg" height="750" alt="33.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/33.jpg" height="750" alt="33.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/34-1273.md
+++ b/content/assets_c/2009/07/34-1273.md
@@ -3,4 +3,4 @@ title: 34-1273
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/34.jpg" height="750" alt="34.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/34.jpg" height="750" alt="34.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/35-1276.md
+++ b/content/assets_c/2009/07/35-1276.md
@@ -3,4 +3,4 @@ title: 35-1276
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/35.jpg" height="750" alt="35.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/35.jpg" height="750" alt="35.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/36-1279.md
+++ b/content/assets_c/2009/07/36-1279.md
@@ -3,4 +3,4 @@ title: 36-1279
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/36.jpg" width="800" alt="36.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/36.jpg" width="800" alt="36.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/37-1282.md
+++ b/content/assets_c/2009/07/37-1282.md
@@ -3,4 +3,4 @@ title: 37-1282
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/37.jpg" width="800" alt="37.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/37.jpg" width="800" alt="37.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/38-1285.md
+++ b/content/assets_c/2009/07/38-1285.md
@@ -3,4 +3,4 @@ title: 38-1285
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/38.jpg" height="750" alt="38.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/38.jpg" height="750" alt="38.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/39-1288.md
+++ b/content/assets_c/2009/07/39-1288.md
@@ -3,4 +3,4 @@ title: 39-1288
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/39.jpg" height="750" alt="39.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/39.jpg" height="750" alt="39.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/40-1291.md
+++ b/content/assets_c/2009/07/40-1291.md
@@ -3,4 +3,4 @@ title: 40-1291
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/40.jpg" width="657" alt="40.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/40.jpg" width="657" alt="40.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/41-1294.md
+++ b/content/assets_c/2009/07/41-1294.md
@@ -3,4 +3,4 @@ title: 41-1294
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/41.jpg" width="800" alt="41.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/41.jpg" width="800" alt="41.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/43-1300.md
+++ b/content/assets_c/2009/07/43-1300.md
@@ -3,4 +3,4 @@ title: 43-1300
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/43.jpg" height="750" alt="43.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/43.jpg" height="750" alt="43.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/44-1303.md
+++ b/content/assets_c/2009/07/44-1303.md
@@ -3,4 +3,4 @@ title: 44-1303
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/44.jpg" height="750" alt="44.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/44.jpg" height="750" alt="44.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/45-1306.md
+++ b/content/assets_c/2009/07/45-1306.md
@@ -3,4 +3,4 @@ title: 45-1306
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/45.jpg" height="750" alt="45.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/45.jpg" height="750" alt="45.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/46-1309.md
+++ b/content/assets_c/2009/07/46-1309.md
@@ -3,4 +3,4 @@ title: 46-1309
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/46.jpg" height="750" alt="46.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/46.jpg" height="750" alt="46.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/47-1312.md
+++ b/content/assets_c/2009/07/47-1312.md
@@ -3,4 +3,4 @@ title: 47-1312
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/47.jpg" width="800" alt="47.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/47.jpg" width="800" alt="47.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/48-1315.md
+++ b/content/assets_c/2009/07/48-1315.md
@@ -3,4 +3,4 @@ title: 48-1315
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/48.jpg" height="750" alt="48.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/48.jpg" height="750" alt="48.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/49-1318.md
+++ b/content/assets_c/2009/07/49-1318.md
@@ -3,4 +3,4 @@ title: 49-1318
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/49.jpg" height="750" alt="49.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/49.jpg" height="750" alt="49.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/50-1321.md
+++ b/content/assets_c/2009/07/50-1321.md
@@ -3,4 +3,4 @@ title: 50-1321
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/50.jpg" height="750" alt="50.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/50.jpg" height="750" alt="50.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/51-1324.md
+++ b/content/assets_c/2009/07/51-1324.md
@@ -3,4 +3,4 @@ title: 51-1324
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/51.jpg" width="800" alt="51.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/51.jpg" width="800" alt="51.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/52-1327.md
+++ b/content/assets_c/2009/07/52-1327.md
@@ -3,4 +3,4 @@ title: 52-1327
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/52.jpg" height="750" alt="52.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/52.jpg" height="750" alt="52.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/53-1330.md
+++ b/content/assets_c/2009/07/53-1330.md
@@ -3,4 +3,4 @@ title: 53-1330
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/53.jpg" height="750" alt="53.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/53.jpg" height="750" alt="53.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/54-1333.md
+++ b/content/assets_c/2009/07/54-1333.md
@@ -3,4 +3,4 @@ title: 54-1333
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/54.jpg" height="750" alt="54.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/54.jpg" height="750" alt="54.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/55-1336.md
+++ b/content/assets_c/2009/07/55-1336.md
@@ -3,4 +3,4 @@ title: 55-1336
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/55.jpg" height="750" alt="55.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/55.jpg" height="750" alt="55.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/56-1339.md
+++ b/content/assets_c/2009/07/56-1339.md
@@ -3,4 +3,4 @@ title: 56-1339
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/56.jpg" height="750" alt="56.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/56.jpg" height="750" alt="56.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/57-1342.md
+++ b/content/assets_c/2009/07/57-1342.md
@@ -3,4 +3,4 @@ title: 57-1342
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/57.jpg" height="750" alt="57.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/57.jpg" height="750" alt="57.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/58-1345.md
+++ b/content/assets_c/2009/07/58-1345.md
@@ -3,4 +3,4 @@ title: 58-1345
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/58.jpg" width="800" alt="58.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/58.jpg" width="800" alt="58.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/59-1348.md
+++ b/content/assets_c/2009/07/59-1348.md
@@ -3,4 +3,4 @@ title: 59-1348
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/59.jpg" height="750" alt="59.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/59.jpg" height="750" alt="59.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/60-1351.md
+++ b/content/assets_c/2009/07/60-1351.md
@@ -3,4 +3,4 @@ title: 60-1351
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/60.jpg" width="800" alt="60.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/60.jpg" width="800" alt="60.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/61-1354.md
+++ b/content/assets_c/2009/07/61-1354.md
@@ -3,4 +3,4 @@ title: 61-1354
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/61.jpg" height="750" alt="61.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/61.jpg" height="750" alt="61.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/64-1363.md
+++ b/content/assets_c/2009/07/64-1363.md
@@ -3,4 +3,4 @@ title: 64-1363
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/64.jpg" width="800" alt="64.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/64.jpg" width="800" alt="64.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/65-1366.md
+++ b/content/assets_c/2009/07/65-1366.md
@@ -3,4 +3,4 @@ title: 65-1366
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/65.jpg" height="750" alt="65.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/65.jpg" height="750" alt="65.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/66-1369.md
+++ b/content/assets_c/2009/07/66-1369.md
@@ -3,4 +3,4 @@ title: 66-1369
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/66.jpg" height="750" alt="66.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/66.jpg" height="750" alt="66.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/67-1372.md
+++ b/content/assets_c/2009/07/67-1372.md
@@ -3,4 +3,4 @@ title: 67-1372
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/67.jpg" width="800" alt="67.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/67.jpg" width="800" alt="67.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/68-1375.md
+++ b/content/assets_c/2009/07/68-1375.md
@@ -3,4 +3,4 @@ title: 68-1375
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/68.jpg" height="750" alt="68.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/68.jpg" height="750" alt="68.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/69-1378.md
+++ b/content/assets_c/2009/07/69-1378.md
@@ -3,4 +3,4 @@ title: 69-1378
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/69.jpg" width="800" alt="69.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/69.jpg" width="800" alt="69.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/70-1381.md
+++ b/content/assets_c/2009/07/70-1381.md
@@ -3,4 +3,4 @@ title: 70-1381
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/70.jpg" height="750" alt="70.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/70.jpg" height="750" alt="70.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/71-1394.md
+++ b/content/assets_c/2009/07/71-1394.md
@@ -3,4 +3,4 @@ title: 71-1394
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/71.jpg" height="750" alt="71.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/71.jpg" height="750" alt="71.jpg" style="margin: 0;padding: 0;border: 0;">

--- a/content/assets_c/2009/07/72-1397.md
+++ b/content/assets_c/2009/07/72-1397.md
@@ -3,4 +3,4 @@ title: 72-1397
 date: 2017-12-17
 type: asset
 ---
-<img src="http://ccnmtl.columbia.edu/projects/histologylab/assets/images/72.jpg" height="750" alt="72.jpg" style="margin: 0;padding: 0;border: 0;">
+<img src="https://histologylab.ctl.columbia.edu/assets/images/72.jpg" height="750" alt="72.jpg" style="margin: 0;padding: 0;border: 0;">


### PR DESCRIPTION
This commit updates any instance of the old url to the current url